### PR TITLE
Call go function asynchronously after fix to dcp-client/index.py

### DIFF
--- a/job-launch-pyodide.py
+++ b/job-launch-pyodide.py
@@ -27,5 +27,5 @@ dcp.set_slice_handler(my_func)
     print("job", job.id, "finished")
     print("results:", pm.eval("Array.from")(results))
 
-dcp_client = pm.require("dcp-client/index.py") # should be just dcp-client, see pm issue 247
+dcp_client = pm.require("dcp-client")
 dcp_client["init"](run_job)

--- a/job-launch.py
+++ b/job-launch.py
@@ -24,5 +24,5 @@ async def run_job():
     print("results:", results)
     pm.eval('console.log')(results)
 
-dcp_client = pm.require('dcp-client/index.py') # should be just dcp-client, see pm issue 247
+dcp_client = pm.require('dcp-client')
 dcp_client['init'](run_job)

--- a/ping-post-init.py
+++ b/ping-post-init.py
@@ -37,4 +37,4 @@ async def go():
 
 dcp_client = pm.require('dcp-client/index.py') # should be just dcp-client, see pm issue 247
 dcp_client['init']()
-#go()
+asyncio.run(go())

--- a/ping-post-init.py
+++ b/ping-post-init.py
@@ -35,6 +35,6 @@ async def go():
     conn.close()
     print('connection closed, exiting');
 
-dcp_client = pm.require('dcp-client/index.py') # should be just dcp-client, see pm issue 247
+dcp_client = pm.require('dcp-client')
 dcp_client['init']()
 asyncio.run(go())

--- a/ping.py
+++ b/ping.py
@@ -35,5 +35,5 @@ async def go():
     conn.close()
     print('connection closed, exiting');
 
-dcp_client = pm.require('dcp-client/index.py') # should be just dcp-client, see pm issue 247
+dcp_client = pm.require('dcp-client')
 dcp_client['init'](go)

--- a/timer-test.py
+++ b/timer-test.py
@@ -8,5 +8,5 @@ const timers = dcp['dcp-timers'];
 timers.setInterval(() => console.log(Date.now()/1000), 2000);
 """);
 
-dcp_client = pm.require('dcp-client/index.py') # should be just dcp-client, see pm issue 247
+dcp_client = pm.require('dcp-client')
 dcp_client['init'](go)

--- a/url-test.py
+++ b/url-test.py
@@ -21,5 +21,4 @@ url;
     except Exception as e:
         print("trapped exception", e)
 
-dcp_client = pm.require('dcp-client/index.py') # should be just dcp-client, see pm issue 247
-dcp_client['init'](go)
+dcp_client = pm.require('dcp-client')

--- a/xhr-fetch.py
+++ b/xhr-fetch.py
@@ -27,5 +27,5 @@ reallyJustFetch(url)
     except Exception as e:
         print("trapped exception", e)
 
-dcp_client = pm.require('dcp-client/index.py') # should be just dcp-client, see pm issue 247
+dcp_client = pm.require('dcp-client')
 dcp_client['init'](go)


### PR DESCRIPTION
Call to go in ping-post-init.py is now in after dependent fix
require dcp-client instead of dcp-client/index.py

Depends on https://gitlab.com/Distributed-Compute-Protocol/dcp-client/-/merge_requests/197 and https://gitlab.com/Distributed-Compute-Protocol/dcp-client/-/merge_requests/189/diffs?commit_id=6c0a87b233e4ec20f41a3c0d06569f61551e5d2a

closes https://github.com/Distributive-Network/PythonMonkey/issues/302